### PR TITLE
Added support for @@include tag which will allow embedding html files from the '_partial' folder

### DIFF
--- a/src/DocNet/SimpleNavigationElement.cs
+++ b/src/DocNet/SimpleNavigationElement.cs
@@ -108,9 +108,12 @@ namespace Docnet
 			sb.Replace("{{Breadcrumbs}}", activePath.CreateBreadCrumbsHTML(relativePathToRoot));
 			sb.Replace("{{ToC}}", activePath.CreateToCHTML(relativePathToRoot));
 			sb.Replace("{{ExtraScript}}", (this.ExtraScriptProducerFunc == null) ? string.Empty : this.ExtraScriptProducerFunc(this));
-
-			// the last action has to be replacing the content marker, so markers in the content which we have in the template as well aren't replaced 
-			sb.Replace("{{Content}}", content);
+            
+            // Check if the content contains @@include tag
+            content = Utils.IncludeProcessor(content, Path.Combine(activeConfig.Source, "_partials"));
+            
+            // the last action has to be replacing the content marker, so markers in the content which we have in the template as well aren't replaced 
+            sb.Replace("{{Content}}", content);
 			Utils.CreateFoldersIfRequired(destinationFile);
 			File.WriteAllText(destinationFile, sb.ToString());
 			if(!this.IsIndexElement)

--- a/src/DocNet/Utils.cs
+++ b/src/DocNet/Utils.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Docnet
@@ -184,5 +185,37 @@ namespace Docnet
 
 			return relativePath;
 		}
-	}
+
+        /// <summary>
+        /// Regex expression used to parse @@include(filename.html) tag.
+        /// </summary>
+        private static Regex includeRegex = new Regex(@"@@include\((.*)\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Process the input for @@include tags and embeds the included content
+        /// into the output.
+        /// </summary>
+        /// <param name="content"></param>
+        /// <param name="partialPath"></param>
+        /// <returns></returns>
+        public static string IncludeProcessor(string content, string partialPath)
+        {
+            Match m = includeRegex.Match(content);
+            while (m.Success)
+            {
+                if (m.Groups.Count > 1)
+                {
+                    string tagToReplace = m.Groups[0].Value;
+                    string fileName = m.Groups[1].Value;
+                    string filePath = Path.Combine(partialPath, fileName);
+                    if (File.Exists(filePath))
+                    {
+                        content = content.Replace(tagToReplace, File.ReadAllText(filePath));
+                    }
+                }
+                m = m.NextMatch();
+            }
+            return content;
+        }
+    }
 }


### PR DESCRIPTION
Include tag allows embedding file into the generated document. This is very useful if you want to embed the same text more than once across different pages. This is a very simplistic implementation which does not require changes to the underlying Markdown parser and uses regex expression.