### PR TITLE
Expose the option for setting the default HTML file extension

### DIFF
--- a/src/DocNet/Config.cs
+++ b/src/DocNet/Config.cs
@@ -64,7 +64,10 @@ namespace Docnet
 				Console.WriteLine("[ERROR] Page template '{0}' is empty.", _configData.PageTemplate);
 				return false;
 			}
-			return true;
+            // Set default extension
+            string defaultExtension = _configData.DefaultExtension;
+            DefaultExtension = string.IsNullOrWhiteSpace(defaultExtension) ? "htm" : defaultExtension;
+            return true;
 		}
 
 
@@ -269,7 +272,12 @@ namespace Docnet
 				}
 				return rawFolderNames.HasValues ? rawFolderNames.Values<string>().ToList() : new List<string>();
 			}
-		} 
-		#endregion
-	}
+		}
+
+        /// <summary>
+        /// File extension to be used for the generated HTML files. Defaults to 'htm'
+        /// </summary>
+        public static string DefaultExtension = "htm";
+        #endregion
+    }
 }

--- a/src/DocNet/SimpleNavigationElement.cs
+++ b/src/DocNet/SimpleNavigationElement.cs
@@ -210,7 +210,7 @@ namespace Docnet
 					_targetURLForHTML = (this.Value ?? string.Empty);
 					if(_targetURLForHTML.ToLowerInvariant().EndsWith(".md"))
 					{
-						_targetURLForHTML = _targetURLForHTML.Substring(0, _targetURLForHTML.Length-3) + ".htm";
+						_targetURLForHTML = String.Format("{0}.{1}", _targetURLForHTML.Substring(0, _targetURLForHTML.Length-3), Config.DefaultExtension);
 					}
 					_targetURLForHTML = _targetURLForHTML.Replace("\\", "/");
 				}


### PR DESCRIPTION
The default file extension is hard coded to 'htm' which acceptable in most of the cases. I work a lot with static file hosting sites like FireBase (from Google) which don't support htm extension for generating SEO friendly URL. Earlier I was using Gulp for renaming htm to html but I would like to move to pure .net solution :-) and get rid of other dependencies.

As a user one has to define a property called 'DefaultExtension' in the config file. If no value is specified the extension defaults to 'htm'.

Note: 
- I am aware that it is not a good practice to add a pubic static member to a class but unfortunately this is the least invasive way I could come up with. Other options will require more changes like passing the config object around(I feel that is a better way as it will make it easier to cater for similar things in the future, but that requires a lot of refactoring). Let me know if you would like to go down that route?
- The extension for Docnet_search is still the same.