### PR TITLE
Do not encode targetUrl as it creates an issue when the home url contain a '/'

### DIFF
--- a/src/DocNet/NavigatedPath.cs
+++ b/src/DocNet/NavigatedPath.cs
@@ -52,7 +52,7 @@ namespace Docnet
 				}
 				else
 				{
-					fragments.Add(string.Format("<li><a href=\"{0}{1}\">{2}</a></li>", relativePathToRoot, HttpUtility.UrlEncode(targetURL), element.Name));
+					fragments.Add(string.Format("<li><a href=\"{0}{1}\">{2}</a></li>", relativePathToRoot, targetURL, element.Name));
 				}
 			}
 			return string.Format("<ul>{0}</ul>{1}", string.Join(" / ", fragments.ToArray()), Environment.NewLine);


### PR DESCRIPTION
This is a corner case which only happens when the __index page is under a folder like in the below case where all my paths are under docs folder. The url which gets generated (`http://localhost:5000/docs%2foverview.html`) has  `/` replaced with `%2f` which changes the path.

```
{
    "Name": "FlexSearch",
    "Source": ".",
    "Destination": "..\\build",
    "Theme": "Default",
	"DefaultExtension": "html",
    "Pages": {
        "__index": "docs/overview.md",
        "FAQ": "docs/faq.md",
        "Getting Started": {
            "__index": "docs/getting-started.md",
            "Essential Path": {
                "Installing FlexSearch": "docs/server-setup/installing.md",
                "Setting up demo index": "docs/demo-index/setting-up-demo-index.md",
                "Search UI": "docs/demo-index/search-ui.md",
                "API Basics": "docs/rest/api-basics.md"
            }.....

```
