### PR TITLE
Link fixes

### DIFF
--- a/src/DocNet/Config.cs
+++ b/src/DocNet/Config.cs
@@ -180,7 +180,10 @@ namespace Docnet
 			searchSimpleElement.ExtraScriptProducerFunc = (e,c,n) => @"
 	<script>var base_url = '.';</script>
 	<script data-main=""js/search.js"" src=""js/require.js""></script>";
-			searchSimpleElement.GenerateOutput(this, activePath, navigationContext);
+
+			// Force custom navigation context because this should end up in the root
+			searchSimpleElement.GenerateOutput(this, activePath, new NavigationContext(PathSpecification.Full, UrlFormatting.None, 0, false));
+
 			activePath.Pop();
 		}
 

--- a/src/DocNet/INavigationElementExtensions.cs
+++ b/src/DocNet/INavigationElementExtensions.cs
@@ -16,12 +16,23 @@ namespace Docnet
 		public static string GetFinalTargetUrl(this INavigationElement navigationElement, NavigationContext navigationContext)
 		{
 			var targetUrl = navigationElement.GetTargetURL(navigationContext);
+			return GetFinalTargetUrl(targetUrl, navigationContext);
+		}
+
+		/// <summary>
+		/// Gets the final URL by encoding the path and by removing the filename if it equals <c>index.htm</c>.
+		/// </summary>
+		/// <param name="targetUrl">The target URL.</param>
+		/// <param name="navigationContext">The navigation context.</param>
+		/// <returns></returns>
+		public static string GetFinalTargetUrl(this string targetUrl, NavigationContext navigationContext)
+		{
 			var link = HttpUtility.UrlPathEncode(targetUrl);
 
 			if (navigationContext.StripIndexHtm)
 			{
 				if (link.Length > IndexHtmFileName.Length &&
-					link.EndsWith(IndexHtmFileName, StringComparison.InvariantCultureIgnoreCase))
+				    link.EndsWith(IndexHtmFileName, StringComparison.InvariantCultureIgnoreCase))
 				{
 					link = link.Substring(0, link.Length - IndexHtmFileName.Length);
 				}

--- a/src/DocNet/NotFoundNavigationElement.cs
+++ b/src/DocNet/NotFoundNavigationElement.cs
@@ -42,7 +42,8 @@ namespace Docnet
 			var destinationFile = Utils.MakeAbsolutePath(config.Destination, this.GetTargetURL(navigationContext));
 
 			var htmlContent = Utils.ConvertMarkdownToHtml(markdownContent, Path.GetDirectoryName(destinationFile), config.Destination, 
-				string.Empty, new List<Heading>(), config.ConvertLocalLinks);
+				string.Empty, new List<Heading>(), config.ConvertLocalLinks, 
+				new NavigationContext(config.PathSpecification, config.UrlFormatting, config.MaxLevelInToC, config.StripIndexHtm));
 			return htmlContent;
 		}
 

--- a/src/DocNet/SimpleNavigationElement.cs
+++ b/src/DocNet/SimpleNavigationElement.cs
@@ -72,7 +72,7 @@ namespace Docnet
 				this.MarkdownFromFile = File.ReadAllText(sourceFile, Encoding.UTF8);
 				// Check if the content contains @@include tag
 				content = Utils.IncludeProcessor(this.MarkdownFromFile, Utils.MakeAbsolutePath(activeConfig.Source, activeConfig.IncludeFolder));
-				content = Utils.ConvertMarkdownToHtml(content, Path.GetDirectoryName(destinationFile), activeConfig.Destination, sourceFile, _relativeLinksOnPage, activeConfig.ConvertLocalLinks);
+				content = Utils.ConvertMarkdownToHtml(content, Path.GetDirectoryName(destinationFile), activeConfig.Destination, sourceFile, _relativeLinksOnPage, activeConfig.ConvertLocalLinks, navigationContext);
 			}
 			else
 			{
@@ -95,7 +95,7 @@ namespace Docnet
 							sibling.GetFinalTargetUrl(navigationContext), Environment.NewLine);
 					}
 					defaultMarkdown.Append(Environment.NewLine);
-					content = Utils.ConvertMarkdownToHtml(defaultMarkdown.ToString(), Path.GetDirectoryName(destinationFile), activeConfig.Destination, string.Empty, _relativeLinksOnPage, activeConfig.ConvertLocalLinks);
+					content = Utils.ConvertMarkdownToHtml(defaultMarkdown.ToString(), Path.GetDirectoryName(destinationFile), activeConfig.Destination, string.Empty, _relativeLinksOnPage, activeConfig.ConvertLocalLinks, navigationContext);
 				}
 				else
 				{
@@ -226,29 +226,7 @@ namespace Docnet
 		{
 			if (_targetURLForHTML == null)
 			{
-				var toReplace = "mdext";
-				var replacement = ".htm";
-
-				var value = (this.Value ?? string.Empty);
-
-				// Replace with custom extension because url formatting might optimize the extension
-				value = value.Replace(".md", toReplace);
-				_targetURLForHTML = value.ApplyUrlFormatting(navigationContext.UrlFormatting);
-
-				if (navigationContext.PathSpecification == PathSpecification.RelativeAsFolder)
-				{
-					if (!IsIndexElement && !_targetURLForHTML.EndsWith($"index{toReplace}", StringComparison.InvariantCultureIgnoreCase))
-					{
-						replacement = "/index.htm";
-					}
-				}
-
-				if (_targetURLForHTML.EndsWith(toReplace, StringComparison.InvariantCultureIgnoreCase))
-				{
-					_targetURLForHTML = _targetURLForHTML.Substring(0, _targetURLForHTML.Length - toReplace.Length) + replacement;
-				}
-
-				_targetURLForHTML = _targetURLForHTML.Replace("\\", "/");
+				_targetURLForHTML = Utils.ResolveTargetURL(this.Value ?? string.Empty, IsIndexElement, navigationContext);
 			}
 
 			return _targetURLForHTML;

--- a/src/DocNet/SimpleNavigationElement.cs
+++ b/src/DocNet/SimpleNavigationElement.cs
@@ -112,7 +112,7 @@ namespace Docnet
 			sb.Replace("{{Footer}}", activeConfig.Footer);
 			sb.Replace("{{TopicTitle}}", this.Name);
 			sb.Replace("{{Path}}", relativePathToRoot);
-			sb.Replace("{{RelativeSourceFileName}}", Utils.MakeRelativePathForUri(activeConfig.Destination, sourceFile).TrimEnd('/'));
+			sb.Replace("{{RelativeSourceFileName}}", Utils.MakeRelativePathForUri(activeConfig.Source, sourceFile).TrimEnd('/'));
 			sb.Replace("{{RelativeTargetFileName}}", Utils.MakeRelativePathForUri(activeConfig.Destination, destinationFile).TrimEnd('/'));
 			sb.Replace("{{Breadcrumbs}}", activePath.CreateBreadCrumbsHTML(relativePathToRoot, navigationContext));
 			sb.Replace("{{ToC}}", activePath.CreateToCHTML(relativePathToRoot, navigationContext));

--- a/src/DocNet/StringExtensions.cs
+++ b/src/DocNet/StringExtensions.cs
@@ -37,6 +37,11 @@ namespace Docnet
 				for(var i = 0; i < splitted.Length; i++)
 				{
 					var splittedValue = splitted[i];
+					if (string.Equals(splittedValue, ".") || string.Equals(splittedValue, ".."))
+					{
+						continue;
+					}
+
 					splittedValue = regEx.Replace(splittedValue, replacementValue).Replace(" ", replacementValue);
 
 					if (!string.IsNullOrEmpty(replacementValue))

--- a/src/DocNet/UrlFormatting.cs
+++ b/src/DocNet/UrlFormatting.cs
@@ -1,9 +1,9 @@
 ﻿namespace Docnet
 {
-    public enum UrlFormatting
-    {
+	public enum UrlFormatting
+	{
 		None,
-        Strip,
-        Dashes
-    }
+		Strip,
+		Dashes
+	}
 }

--- a/src/MarkdownDeep/MarkdownDeep.cs
+++ b/src/MarkdownDeep/MarkdownDeep.cs
@@ -880,6 +880,14 @@ namespace MarkdownDeep
 	    /// </summary>
 	    public bool ConvertLocalLinks { get; set; }
 
+        /// <summary>
+        /// Gets or sets the local link processor allowing customization of the local links before being transformed.
+        /// </summary>
+        /// <value>
+        /// The local link processor.
+        /// </value>
+        public Func<string, string> LocalLinkProcessor { get; set; }
+
         // When set, all html block level elements automatically support
         // markdown syntax within them.  
         // (Similar to Pandoc's handling of markdown in html)


### PR DESCRIPTION
This PR solves 3 issues:

1. RelativeSourceFileName was resolved against the destination instead of source
2. Relative files inside the .md files now respect the PathSpecification. This means that if a user picks RelativeAsFolder, you can still use relative links to .md files on source, they will now be converted to the correct target url by the markdown processor.
3. Use custom NavigationContext for search to ensure search works regardless of PathSpecification